### PR TITLE
Autonomous fix

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -164,7 +164,7 @@
                     <ons-button modifier="large" data-select="move">Moved but did not cross line</ons-button>
                     <ons-button modifier="large" data-select="none">Did not move</ons-button>
                 </div>
-                Choose target:<br />
+                Choose target (If none, leave blank):<br />
                 <div id="auto-target" class="btn-select-menu">
                     <ons-button modifier="large" data-select="sswitch" disabled>Switch (Same side)</ons-button>
                     <ons-button modifier="large" data-select="cswitch" disabled>Switch (Cross side)</ons-button>


### PR DESCRIPTION
Fixes #15 although in a slightly different way than before.

New way:
You select whether they moved, crossed line, or stayed put. If they crossed the line, you have the option to choose their target.

Why this? After discussion with Devansh, we agreed that it was unlikely teams would do multiple targets of autonomous (e.g. putting two cubes in the switch). Similarly, it is unlikely teams would do two separate targets (e.g. switch and scale). The only time there are two "targets" is when they cross the line and put something in the switch, but crossing the line is in its own separate section now anyway.

Perhaps a different way would be to allow multiple selections, but this has the complicating factor is that registering two switches is impossible but a switch and a scale is possible which is weird. If we really want this functionality, we need to overhaul the autonomous, both ui and structure and change it completely.